### PR TITLE
Always use mentions instead of display names

### DIFF
--- a/commands/banditten.js
+++ b/commands/banditten.js
@@ -16,6 +16,6 @@ module.exports = {
 
 function pullBandit(message){
     soundUtils.play(message.client.voiceconnection, "./sound/banditten.mp3");
-    channelUtils.sendMessage(message.channel, channelUtils.mention(message.member.id) + " rykkede i banditten")
+    channelUtils.sendMention(message.channel, message.member.id, " rykkede i banditten")
 }
 

--- a/commands/banditten.js
+++ b/commands/banditten.js
@@ -16,6 +16,6 @@ module.exports = {
 
 function pullBandit(message){
     soundUtils.play(message.client.voiceconnection, "./sound/banditten.mp3");
-    channelUtils.sendMessage(message.channel, message.member.displayName + " rykkede i banditten")
+    channelUtils.sendMessage(message.channel, channelUtils.mention(message.member.id) + " rykkede i banditten")
 }
 

--- a/commands/disko.js
+++ b/commands/disko.js
@@ -12,7 +12,7 @@ module.exports = {
         } else if (args.length > 1){
             const klandret = args[1];
             //If no third argument given, assume klandrer is sender of messages.
-            const klandrer = args[2]? args[2] : "<@" + message.author.id + ">";
+            const klandrer = args[2]? args[2] : channelUtils.mention(message.author.id);
 
             if (args[0]==="add"){
                 diskoUtils.addRemoveKlandring(message, klandrer, klandret, 1);

--- a/commands/kapsel.js
+++ b/commands/kapsel.js
@@ -103,7 +103,7 @@ function hitSkraldespanden(message){
 }
 
 function hitPerson(target, message){
-    channelUtils.sendMessage(message.channel, "<@"+message.author.id+"> rammer <@"+target+"> med en kapsel!");
+    channelUtils.sendMessage(message.channel, channelUtils.mention(message.author.id) + " rammer " + channelUtils.mention(target) + " med en kapsel!");
     //If target is bot:
     if (target === message.client.user.id) {
         channelUtils.sendMessage(message.channel, "AAAAAAAAV!!!\n Høker!!!\n - bare gi' den til FORM!");	

--- a/commands/kapsel.js
+++ b/commands/kapsel.js
@@ -103,7 +103,7 @@ function hitSkraldespanden(message){
 }
 
 function hitPerson(target, message){
-    channelUtils.sendMessage(message.channel, channelUtils.mention(message.author.id) + " rammer " + channelUtils.mention(target) + " med en kapsel!");
+    channelUtils.sendMention(message.channel, message.author.id, " rammer " + channelUtils.mention(target) + " med en kapsel!");
     //If target is bot:
     if (target === message.client.user.id) {
         channelUtils.sendMessage(message.channel, "AAAAAAAAV!!!\n Høker!!!\n - bare gi' den til FORM!");	

--- a/commands/klokken.js
+++ b/commands/klokken.js
@@ -18,6 +18,6 @@ module.exports = {
 
 function ringKlokke(message){
     soundUtils.play(message.client.voiceconnection, "./sound/klokke.mp3");
-    channelUtils.sendMessage(message.channel, channelUtils.mention(message.member.id) + " ringede med klokken!")
+    channelUtils.sendMention(message.channel, message.member.id, " ringede med klokken!")
 }
 

--- a/commands/klokken.js
+++ b/commands/klokken.js
@@ -18,6 +18,6 @@ module.exports = {
 
 function ringKlokke(message){
     soundUtils.play(message.client.voiceconnection, "./sound/klokke.mp3");
-    channelUtils.sendMessage(message.channel, message.member.displayName + " ringede med klokken!")
+    channelUtils.sendMessage(message.channel, channelUtils.mention(message.member.id) + " ringede med klokken!")
 }
 

--- a/commands/pb.js
+++ b/commands/pb.js
@@ -17,6 +17,6 @@ module.exports = {
 
 function startPb(message){
     soundUtils.play(message.client.voiceconnection, "./sound/pb.mp3");
-    channelUtils.sendMessage(message.channel, message.member.displayName + " startede en pædagogisk bundecirkel!")
+    channelUtils.sendMessage(message.channel, channelUtils.mention(message.member.id) + " startede en pædagogisk bundecirkel!")
 }
 

--- a/commands/pb.js
+++ b/commands/pb.js
@@ -17,6 +17,6 @@ module.exports = {
 
 function startPb(message){
     soundUtils.play(message.client.voiceconnection, "./sound/pb.mp3");
-    channelUtils.sendMessage(message.channel, channelUtils.mention(message.member.id) + " startede en pædagogisk bundecirkel!")
+    channelUtils.sendMention(message.channel, message.member.id, " startede en pædagogisk bundecirkel!")
 }
 

--- a/utils/bundekortutils.js
+++ b/utils/bundekortutils.js
@@ -36,7 +36,7 @@ function listCards(wallet){
     let msg = "";
     wallet.cards.forEach(bundekort => {
         msg += "ID: " + bundekort._id + "\n";
-        msg += "Fra <@" + bundekort.authorid + ">:\n";
+        msg += "Fra " + channelUtils.mention(bundekort.authorid) + ":\n";
         msg += bundekort.text + "\n\n";
     })
     return msg
@@ -86,7 +86,7 @@ async function useCard(message, id){
             channelUtils.reply(message, "Bundekortet med id " + card._id + " er nu brugt!");
             collector.stop();
         });
-        channelUtils.sendMessage(message.channel, "<@" + recipient + "> - Du modtager et bundekort med teksten:\n" + card.text + "\n Underskrevet: <@" + card.authorid + ">\n Send \"!bundekort ok " + card._id + "\" inden for 5 minutter for at acceptere.")
+        channelUtils.sendMessage(message.channel, channelUtils.mention(recipient) + " - Du modtager et bundekort med teksten:\n" + card.text + "\n Underskrevet: " + channelsUtils.mention(card.authorid) + "\n Send \"!bundekort ok " + card._id + "\" inden for 5 minutter for at acceptere.")
     }
 }
 
@@ -109,7 +109,7 @@ async function sendById(message, recipient, cardid){
     } else {
         removeCard(card, message.author.id);
         addCard(card, recipient);
-        channelUtils.reply(message, "Bundekortet på <@" + card.authorid + "> er blevet sendt!" )
+        channelUtils.reply(message, "Bundekortet på " + channelUtils.mention(card.authorid) + " er blevet sendt!" )
     }
     console.log(card);
 }

--- a/utils/bundekortutils.js
+++ b/utils/bundekortutils.js
@@ -86,7 +86,7 @@ async function useCard(message, id){
             channelUtils.reply(message, "Bundekortet med id " + card._id + " er nu brugt!");
             collector.stop();
         });
-        channelUtils.sendMessage(message.channel, channelUtils.mention(recipient) + " - Du modtager et bundekort med teksten:\n" + card.text + "\n Underskrevet: " + channelsUtils.mention(card.authorid) + "\n Send \"!bundekort ok " + card._id + "\" inden for 5 minutter for at acceptere.")
+        channelUtils.sendMention(message.channel, recipient, " - Du modtager et bundekort med teksten:\n" + card.text + "\n Underskrevet: " + channelsUtils.mention(card.authorid) + "\n Send \"!bundekort ok " + card._id + "\" inden for 5 minutter for at acceptere.")
     }
 }
 

--- a/utils/channelutils.js
+++ b/utils/channelutils.js
@@ -6,6 +6,7 @@ module.exports = {
     sendMessage:sendMessage,
     reply:reply,
     dm:dm,
+    mention:mention,
 }
 
 function reply(message, reply){
@@ -41,4 +42,6 @@ function sanitize(channel, text){
     return text;
 }
 
-
+function mention(id) {
+    return "<@" + id + ">";
+}

--- a/utils/channelutils.js
+++ b/utils/channelutils.js
@@ -7,6 +7,7 @@ module.exports = {
     reply:reply,
     dm:dm,
     mention:mention,
+    sendMentionMessage:sendMentionMessage,
 }
 
 function reply(message, reply){
@@ -44,4 +45,8 @@ function sanitize(channel, text){
 
 function mention(id) {
     return "<@" + id + ">";
+}
+
+function sendMentionMessage(channel, id, message) {
+    sendMessage(channel, mention(id) + message);
 }

--- a/utils/skilteutils.js
+++ b/utils/skilteutils.js
@@ -38,7 +38,7 @@ async function ned(message){
     if (!skiltet.status.isUp) {
         channelUtils.reply("Skiltet er faldet ned i forvejen");
     } else {
-        dbHandler.updateOne(Status, {"_id":"skiltet"}, {"status.isUp":false, "status.lastDown":message.member.displayName})
+        dbHandler.updateOne(Status, {"_id":"skiltet"}, {"status.isUp":false, "status.lastDown":channelUtils.mention(message.member.id)})
             .catch(() => dbError());
         return tavleUtils.tavlegrund(message, "Du har hærget skiltet.");
     }

--- a/utils/tavleutils.js
+++ b/utils/tavleutils.js
@@ -95,7 +95,7 @@ async function printById(message, id){
     if (entry){
         channelUtils.sendMessage(message.channel, entry.alias + " er på tavlen i " + entry.potens + ". potens.")
     } else {
-        channelUtils.sendMessage(message.channel, "<@" + id + "> er ikke på tavlen.")
+        channelUtils.sendMessage(message.channel, channelUtils.mention(id) + " er ikke på tavlen.")
     }
 }
 

--- a/utils/tavleutils.js
+++ b/utils/tavleutils.js
@@ -63,7 +63,7 @@ async function tavlegrund(message, reason){
         .catch(() => dbError());
     const name = message.member.displayName;
     påAfTavlen(message.client, id, 1, name);
-    channelUtils.sendMessage(message.channel, "**" + name + " på tavlen!**\n Grund: " + reason);
+    channelUtils.sendMessage(message.channel, "**" + channelUtils.mention(id) + " på tavlen!**\n Grund: " + reason);
     console.log(name + " (" + id + ") er kommet på tavlen for " + reason);
 }
 

--- a/utils/tavleutils.js
+++ b/utils/tavleutils.js
@@ -95,7 +95,7 @@ async function printById(message, id){
     if (entry){
         channelUtils.sendMessage(message.channel, entry.alias + " er på tavlen i " + entry.potens + ". potens.")
     } else {
-        channelUtils.sendMessage(message.channel, channelUtils.mention(id) + " er ikke på tavlen.")
+        channelUtils.sendMention(message.channel, id, " er ikke på tavlen.")
     }
 }
 


### PR DESCRIPTION
This should prevent the bot from mentioning the wrong people,
when a user has a display name of `@everyone` or `<@id>`.